### PR TITLE
fix: fixed the compiler compiling XOR as OR

### DIFF
--- a/yuri/compiler/compiler.py
+++ b/yuri/compiler/compiler.py
@@ -347,7 +347,7 @@ def compile_file(
     return ntxt, nsvar, nlvar, lblpos, syms, ybnseg
 
 
-AOpIns = [IOpB.NOP, IOpB.ADD, IOpB.SUB, IOpB.MUL, IOpB.DIV, IOpB.MOD, IOpB.BAND, IOpB.BOR, IOpB.BOR]
+AOpIns = [IOpB.NOP, IOpB.ADD, IOpB.SUB, IOpB.MUL, IOpB.DIV, IOpB.MOD, IOpB.BAND, IOpB.BOR, IOpB.BXOR]
 
 
 def astop_to_aop(op: ast.operator) -> int:


### PR DESCRIPTION
compiler compiling XOR as OR
Judging by the code and case ast.BitXor(): return 8 , it should be BXOR, not BOR.
This error would sooner or later break situations with bitwise XOR operations.