### PR TITLE
fix: make decompiler available for use on lower Python versions

### DIFF
--- a/yuri/decompiler/base.py
+++ b/yuri/decompiler/base.py
@@ -149,7 +149,7 @@ class YDecBase(ABC):
                 case (IOpV(opv), tyq, idx):
                     match opv:
                         case IOpV.VAR: stk.append(self.var_to_ast(tyq, idx, lvars))
-                        case IOpV.ARR: stk.append(ast.Call(self.var_to_ast(tyq, idx, lvars)))
+                        case IOpV.ARR: stk.append(ast.Call(self.var_to_ast(tyq, idx, lvars), args=[], keywords=[]))
                         case _:  # None, arr, dims
                             stk.append(None)
                             stk.append(self.var_to_ast(tyq, idx, lvars))
@@ -160,12 +160,12 @@ class YDecBase(ABC):
                     assert len(dims) >= 2
                     arr = dims.pop()
                     dims.reverse()
-                    stk.append(ast.Call(arr, dims))
+                    stk.append(ast.Call(arr, dims, keywords=[]))
                 case IOpB.NOP: pass
                 case IOpB.TOI | IOpB.TOS:
                     assert (exp := stk.pop()) is not None
                     astname = self.AstNameTOI if ins == IOpB.TOI else self.AstNameTOS
-                    stk.append(ast.Call(astname, [exp]))
+                    stk.append(ast.Call(astname, [exp], keywords=[]))
                 case IOpB.NEG:
                     assert (exp := stk.pop()) is not None
                     stk.append(ast.UnaryOp(AstOpUSub, exp))

--- a/yuri/decompiler/yuri.py
+++ b/yuri/decompiler/yuri.py
@@ -75,14 +75,14 @@ class YDecYuri(YDecBase):
                     # if elif -> [-3][-1]if [-2]if/elif.else [-1]elif.body
                     assert narg == 3
                     assert isinstance(dat := args[0].dat, list)
-                    stk[-1].append(ifs := ast.If(self.ins_to_ast(dat, lvars)))
+                    stk[-1].append(ifs := ast.If(self.ins_to_ast(dat, lvars), body=[], orelse=[]))
                     stk.append(ifs.body)
                     ctl.append(Ctl.IF)
                 case codes.ELSE if narg == 3:
                     assert (top := ctl[-1]) in CtlIfElif
                     assert isinstance(dat := args[0].dat, list)
                     assert isinstance(ifs := stk[-2][-1], ast.If)
-                    ifs.orelse.append(eifs := ast.If(self.ins_to_ast(dat, lvars)))
+                    ifs.orelse.append(eifs := ast.If(self.ins_to_ast(dat, lvars), body=[], orelse=[]))
                     if top == Ctl.IF:
                         stk.append(eifs.body)
                         ctl.append(Ctl.ELIF)
@@ -115,7 +115,7 @@ class YDecYuri(YDecBase):
                 case codes.LOOP:
                     assert narg == 2
                     assert isinstance(dat := args[0].dat, list)
-                    stk[-1].append(ws := ast.While(self.ins_to_ast(dat, lvars)))
+                    stk[-1].append(ws := ast.While(self.ins_to_ast(dat, lvars), body=[], orelse=[]))
                     stk.append(ws.body)
                     ctl.append(Ctl.LOOP)
                 case codes.LOOPEND:
@@ -175,7 +175,7 @@ class YDecYuri(YDecBase):
                             stk[-1].append(ast.Assign([lsub], rhsast, lineno=0))
                 case code:
                     cmdname, argnames = cnames[code]
-                    c_call = ast.Call(ast.Name(cmdname))
+                    c_call = ast.Call(ast.Name(cmdname), args=[], keywords=[])
                     kwlist = c_call.keywords
                     aolist: list[ast.stmt] = []
                     for arg in args:
@@ -192,4 +192,4 @@ class YDecYuri(YDecBase):
                         stk[-1].append(ast.With([ast.withitem(c_call)], aolist, lineno=0))
                     else:
                         stk[-1].append(ast.Expr(c_call))
-        return ast.unparse(ast.Module(root))
+        return ast.unparse(ast.Module(root, type_ignores=[]))

--- a/yuri/decompiler/yuris.py
+++ b/yuri/decompiler/yuris.py
@@ -134,7 +134,7 @@ class YDecYuris(YDecBase):
 
 
 AstEmpty = ast.Name('')
-def force_paren(e: ast.expr) -> ast.expr: return ast.Call(AstEmpty, [e])
+def force_paren(e: ast.expr) -> ast.expr: return ast.Call(AstEmpty, [e], keywords=[])
 
 
 def yuris_prec(e: ast.expr) -> tuple[int, ast.expr]:


### PR DESCRIPTION
Adds some default arguments needed by ast. Tested on Python 3.12.

(seems there's no direct replacement for the `optimize` argument of `ast.parse`, so compiler cannot be simply fixed.)